### PR TITLE
[HDR-3940] BE - Return Non Parseable Text as it is

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -19,7 +19,12 @@ module Audited
     class << self
       def load(obj)
         if text_column?
-          ActiveRecord::Coders::YAMLColumn.new(Object).load(obj)
+          begin
+            ActiveRecord::Coders::YAMLColumn.new(Object).load(obj)
+          rescue Psych::SyntaxError
+            obj = obj.gsub("=>", ":")
+            ActiveRecord::Coders::YAMLColumn.new(Object).load(obj)
+          end
         else
           obj
         end


### PR DESCRIPTION
https://accredible.atlassian.net/browse/HDR-3940

**Issue**: 
We store `audited_changes` as JSON parseable string: "{\"a\":1}" which can be parsed by Audit gem serializer: YAMLIfTextColumnType
But some data are incorrectly stored as non parseable string: {\"a\" => 1}" which gives raises Psych::SyntaxError https://app.bugsnag.com/accredible/acms-api/errors/68a4828815e70991bae806b3?filters[event.since]=30d&filters[error.status]=open&filters[search]=psych

It is unknown to me how such datas got stored in the very first place. I tried to find sources but couldn't find any. So my assumption is that such bad data got stored due to some temporary code changes which then later got corrected.

**Solution** 
Revert to existing behaviour of returning the text as it is if it could not be parsed
